### PR TITLE
Build patched virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,9 @@ __pycache__
 /examples/ffi_demo/ffi_demo
 /examples/ffi_demo/build
 /examples/result
+/venv-patched
+
+/build
+/algorithm_reference_library.egg-info/
 
 **/*.class

--- a/tools/patched_virtualenv.sh
+++ b/tools/patched_virtualenv.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Creates a virtualenv and applies (so far) a patch to SciPy 1.0.0 in order to
+# deal with _minpack not being thread-safe, breaking multithreaded applications.
+
+
+REALPATH=$(realpath $0)
+
+ARLROOT=$(dirname $(dirname $REALPATH))
+
+cd $ARLROOT/tools
+
+VENV=$ARLROOT/venv-patched
+
+if [[ -d $VENV ]]; then
+	echo "Found virtualenv (or conflicting directory) in $VENV"
+else
+	echo "Did not find a virtualenv in $VENV. Creating..."
+	virtualenv $VENV
+	source $VENV/bin/activate
+
+	PKGDIR=$VIRTUAL_ENV/lib/python3.6/site-packages
+
+	echo "Installing requirements.txt..."
+	pip install -r $ARLROOT/requirements.txt
+
+	# Check for patch requirements
+	# Scipy 1.0.0 has a thread safety issue in _minpack. Test for this version,
+	# and apply patch @ https://github.com/scipy/scipy/pull/7999.
+	# N.B. Worked around in 1.1.0
+	SCIPYVER=$(pip list 2>/dev/null |sed -En 's/scipy \(([0-9\.]*)\)/\1/p')
+	if [ $SCIPYVER == "1.0.0" ]; then
+		echo "Found scipy version: $SCIPYVER. Applying thread-safety patch for minpack."
+
+		curl -o minpack.patch https://patch-diff.githubusercontent.com/raw/scipy/scipy/pull/7999.patch
+
+		pushd $PKGDIR
+		patch -p1 -u < $ARLROOT/tools/minpack.patch
+		popd
+
+		rm minpack.patch
+	fi
+
+fi


### PR DESCRIPTION
Sometimes it is necessary to patch dependencies to work around issues that haven't been fixed in a release. Currently there is an issue with SciPy 1.0.0's implentation of `minpack`, which is not thread safe and causes crashes in multithreaded execution frameworks (like StarPU).

This script creates a virtualenv, installs the ARL requirements and applies the required upstream patch(es). Only this specific issue is being patched right now, but more may show up during further testing.