### PR TITLE
devops: modifications to support k8s devops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Universal image for running Notebook, Dask pipelines, libs, and lint checkers
-ARG PYTHON=python3.6
+ARG PYTHON=python3
 
 FROM ubuntu:18.04
 
@@ -38,12 +38,6 @@ RUN if [ ! -f /usr/bin/node ]; then ln -s /usr/bin/nodejs /usr/bin/node ; fi && 
 # sort out pip and python for 3.6
 RUN cd /src; wget https://bootstrap.pypa.io/get-pip.py && ${PYTHON} get-pip.py; \
     rm -rf /root/.cache
-
-RUN if [ "${PYTHON}" = "python3.6" ] ; then ln -s /usr/bin/python3.6 /usr/local/bin/python3 && \
-    rm -f /usr/bin/python3 && ln -s /usr/bin/python3.6 /usr/bin/python3 ; fi && \
-    python3 --version && \
-    pip3 --version
-
 
 # Install Tini
 RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.18.0/tini && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,121 @@
+# Universal image for running Notebook, Dask pipelines, libs, and lint checkers
+ARG PYTHON=python3
+
+FROM alpine:3.7
+
+ARG PYTHON
+
+MAINTAINER Piers Harding "piers@catalyst.net.nz"
+
+ENV HOME /root
+ENV PYTHON_PIP_VERSION 10.0.1
+
+# Add and install Python modules
+ADD ./requirements.txt /src/requirements.txt
+
+# the package basics for Python 3
+RUN apk add --update --no-cache ${PYTHON} py3-pip \
+    openssl ca-certificates
+
+#  openblas-dev
+
+RUN \
+    apk add --update --no-cache --virtual build-dependencies \
+    wget bash make tini \
+    git curl openssl ca-certificates net-tools vim \
+    py3-virtualenv \
+    py3-nose nodejs nodejs-npm \
+    graphviz freetype libpng \
+    python3-tkinter \
+    py3-lxml py3-numpy py3-numpy-f2py py-numpy-dev \
+    libgomp lapack && \
+    apk add --update --no-cache --virtual .build-deps \
+    build-base  python3-dev freetype-dev libpng-dev \
+    gcc gfortran musl-dev g++ bzip2-dev coreutils \
+    dpkg-dev dpkg expat-dev gdbm-dev libc-dev \
+    libnsl-dev libressl libressl-dev libtirpc-dev \
+    linux-headers ncurses-dev pax-utils \
+    readline-dev sqlite-dev tcl-dev tk tk-dev \
+    xz-dev zlib-dev libxml2-dev libxslt-dev \
+    libffi-dev lapack-dev jpeg-dev && \
+    apk add --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing --update hdf5-dev && \
+    wget -qO- https://github.com/git-lfs/git-lfs/releases/download/v2.4.2/git-lfs-linux-amd64-2.4.2.tar.gz | tar xz && \
+    mv git-lfs-*/git-lfs /usr/bin/ && rm -rf git-lfs-* && \
+    git lfs install && \
+    ln -s /usr/include/locale.h /usr/include/xlocale.h && \
+    if [ ! -f /usr/bin/node ]; then ln -s /usr/bin/nodejs /usr/bin/node ; fi && \
+    node --version && \
+    wget --quiet https://github.com/krallin/tini/releases/download/v0.18.0/tini && \
+    echo "12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855 *tini" | sha256sum -c - && \
+    mv tini /usr/local/bin/tini && \
+    chmod +x /usr/local/bin/tini && \
+    cd /src && wget https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py --disable-pip-version-check \
+        --no-cache-dir "pip==$PYTHON_PIP_VERSION" && \
+    rm -f get-pip.py && \
+    pip3 install bokeh && \
+    pip3 install pytest && \
+    pip3 install flake8 && \
+    pip3 install Cython && \
+    cd /src && pip3 install -r requirements.txt && \
+    pip3 install jupyter_nbextensions_configurator && \
+    pip3 install jupyter_contrib_nbextensions && \
+    pip3 install -U pylint && \
+    rm -rf /root/.cache && \
+    jupyter contrib nbextension install --system --symlink && \
+    jupyter nbextensions_configurator enable --system && \
+    apk del .build-deps && \
+    rm -rf /var/cache/apk/*
+
+# python must exist
+RUN \
+    if [ ! -f /usr/bin/python ]; then ln -s /usr/bin/python3 /usr/bin/python ; fi
+
+#RUN pip3 install jupyterlab
+#RUN jupyter serverextension enable --py jupyterlab --sys-prefix
+#RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager
+#RUN jupyter labextension install jupyterlab_bokeh
+
+# runtime specific environment
+ENV JENKINS_URL 1
+ENV PYTHONPATH /arl
+ENV JUPYTER_PATH /arl/examples/arl
+
+RUN touch "${HOME}/.bash_profile"
+
+# Bundle app source
+ADD ./docker/boot.sh /
+ADD ./libs /arl/libs/
+ADD ./Makefile /arl/
+ADD ./examples /arl/examples/
+ADD ./tests /arl/tests/
+ADD ./setup.py ./README.md /arl/
+ADD ./data_models /arl/data_models/
+ADD ./processing_components /arl/processing_components/
+ADD ./util /arl/util/
+ADD ./workflows /arl/workflows/
+
+# run setup
+RUN cd /arl && ${PYTHON} setup.py build && ${PYTHON} setup.py install
+
+# create space for libs
+RUN mkdir -p /arl/test_data /arl/test_results && \
+    chmod 777 /arl /arl/test_data /arl/test_results && \
+    chmod -R a+w /arl
+
+COPY --chown="1000:100" ./docker/jupyter_notebook_config.py "${HOME}/.jupyter/"
+COPY ./docker/notebook.sh /usr/local/bin/
+COPY ./docker/start-dask-scheduler.sh /usr/local/bin/
+COPY ./docker/start-dask-worker.sh /usr/local/bin
+
+# We share in the arl data here
+VOLUME ["/arl/data", "/arl/tmp"]
+
+# Expose Jupyter and Bokeh ports
+EXPOSE  8888 8786 8787 8788 8789
+
+# Setup the entrypoint or environment
+ENTRYPOINT ["/sbin/tini", "--"]
+
+# Run - default is notebook
+CMD ["/boot.sh"]

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -80,6 +80,18 @@ Step 2/44 : FROM ubuntu:18.04
 ...
 ```
 
+Alternatively we can use registry credentials declared in the resource descriptor to pull the image from remote:
+```
+...
+      imagePullSecrets:
+        - name: arlregcred
+...
+```
+To enable this we need to create a Kubernetes Secret that holds the container registry credentials called arlregcred:
+```
+kubectl create secret docker-registry arlregcred --docker-server=<registry.domain.name> --docker-username=<username> --docker-password=<password> --docker-email=<you@email.address?
+```
+
 Test that this is correctly accessible by launching a test app:
 ```
 kubectl run test-arl --rm -it --image arl_img:latest --image-pull-policy=IfNotPresent -- bash
@@ -215,9 +227,12 @@ helm install --name <app instance> arl-cluster/
 ```
 Individual values from the values.yaml file can be overridden with: `--set worker.replicaCount=10,resource.limits.cpu=1000m,resource.limits.memory=4098Mi` etc.
 
-You will get output like the following:
+You will get output like the following (adjust for your registry and credentials):
 ```
-k8s$ helm install --name test arl-cluster/
+k8s$ helm install --name test arl-cluster/ --wait \
+      --set image.repository="registry.gitlab.com/piersharding/arl-devops/arl_img" \
+      --set image.tag="1b47647d" \
+      --set image.secrets[0].name="gitlab-registry"
 NAME:   test
 LAST DEPLOYED: Fri Jun  1 10:02:58 2018
 NAMESPACE: default

--- a/k8s/arl-cluster/templates/k8s-dask-notebook-deployment.yml
+++ b/k8s/arl-cluster/templates/k8s-dask-notebook-deployment.yml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: notebook
-  namespace: default
+  namespace: {{ .Release.Namespace }}
   labels:
     app: notebook-{{ template "arl-cluster.name" . }}
     chart: {{ template "arl-cluster.chart" . }}
@@ -22,13 +22,15 @@ spec:
         app: notebook-{{ template "arl-cluster.name" . }}
         release: {{ .Release.Name }}
     spec:
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
       containers:
       - name: notebook-{{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: ARL_DASK_SCHEDULER
-            value: dask-scheduler-{{ template "arl-cluster.fullname" . }}.default.svc.cluster.local:8786
+            value: dask-scheduler-{{ template "arl-cluster.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8786
           - name: JUPYTER_PASSWORD
             value: "{{ .Values.jupyter.password }}"
           - name: NOTEBOOK_PORT

--- a/k8s/arl-cluster/templates/k8s-dask-scheduler-deployment.yml
+++ b/k8s/arl-cluster/templates/k8s-dask-scheduler-deployment.yml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dask-scheduler
-  namespace: default
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dask-scheduler-{{ template "arl-cluster.name" . }}
     chart: {{ template "arl-cluster.chart" . }}
@@ -22,6 +22,8 @@ spec:
         app: dask-scheduler-{{ template "arl-cluster.name" . }}
         release: {{ .Release.Name }}
     spec:
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
       containers:
       - name: scheduler
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/k8s/arl-cluster/templates/k8s-dask-worker-deployment.yml
+++ b/k8s/arl-cluster/templates/k8s-dask-worker-deployment.yml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dask-worker-{{ template "arl-cluster.fullname" . }}
-  namespace: default
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dask-worker-{{ template "arl-cluster.name" . }}
     chart: {{ template "arl-cluster.chart" . }}
@@ -23,6 +23,8 @@ spec:
         release: {{ .Release.Name }}
     spec:
       # hostNetwork: true
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
       containers:
       - name: worker
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -37,7 +39,7 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
           - name: DASK_SCHEDULER
-            value: dask-scheduler-{{ template "arl-cluster.fullname" . }}.default.svc.cluster.local
+            value: dask-scheduler-{{ template "arl-cluster.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
           - name: DASK_PORT_NANNY
             value: "8789"
           - name: DASK_PORT_WORKER
@@ -86,7 +88,7 @@ spec:
           containerPort: 8787
         readinessProbe:
           httpGet:
-            path: /json/identity.json
+            path: /
             port: 8787
           initialDelaySeconds: 60
           timeoutSeconds: 10

--- a/k8s/arl-cluster/values.yaml
+++ b/k8s/arl-cluster/values.yaml
@@ -9,6 +9,7 @@ image:
   repository: arl_img
   tag: latest
   pullPolicy: IfNotPresent
+  pullSecret: gitlab-registry
 
 jupyter:
   password: changeme

--- a/k8s/resources/k8s-dask-notebook-deployment.yml
+++ b/k8s/resources/k8s-dask-notebook-deployment.yml
@@ -32,6 +32,8 @@ spec:
       labels:
         k8s-app: notebook
     spec:
+      imagePullSecrets:
+        - name: arlregcred
       containers:
       - name: notebook
         image: ${DOCKER_IMAGE}

--- a/k8s/resources/k8s-dask-scheduler-deployment.yml
+++ b/k8s/resources/k8s-dask-scheduler-deployment.yml
@@ -36,6 +36,8 @@ spec:
       labels:
         k8s-app: dask-scheduler
     spec:
+      imagePullSecrets:
+        - name: arlregcred
       containers:
       - name: scheduler
         image: ${DOCKER_IMAGE}

--- a/k8s/resources/k8s-dask-worker-deployment.yml
+++ b/k8s/resources/k8s-dask-worker-deployment.yml
@@ -15,6 +15,8 @@ spec:
         k8s-app: dask-worker
     spec:
       # hostNetwork: true
+      imagePullSecrets:
+        - name: arlregcred
       containers:
       - name: worker
         image: ${DOCKER_IMAGE}

--- a/libs/image/operations.py
+++ b/libs/image/operations.py
@@ -65,7 +65,6 @@ def create_image(npixel=512, cellsize=0.000015, polarisation_frame=PolarisationF
     return create_image_from_array(numpy.zeros(shape), w, polarisation_frame=polarisation_frame)
 
 
-
 def create_image_from_array(data: numpy.array, wcs: WCS, polarisation_frame: PolarisationFrame) -> Image:
     """ Create an image from an array and optional wcs
 

--- a/tests/processing_components/test_visibility_ms.py
+++ b/tests/processing_components/test_visibility_ms.py
@@ -86,7 +86,7 @@ class TestCreateMS(unittest.TestCase):
     
         msfile = arl_path("data/vis/ASKAP_example.ms")
         
-        from workflows.arlexecute.processing_component_interface.execution_support.arlexecute import arlexecute
+        from workflows.arlexecute.execution_support.arlexecute import arlexecute
         arlexecute.set_client(use_dask=False)
     
         nchan_ave = 16


### PR DESCRIPTION
* add alpine based build
* make tests selectable
* remove docker test reliance on local storage (volumes now)
* switch off docker run -ti
* add Docker registry credentials to k8s resource descriptors
* make k8s namespaces variable
* fix lint errors

These changes are in support of https://gitlab.com/piersharding/arl-devops - automated devops on Kubernetes (Minikube so far).