### PR TITLE
Adding support for daliuge as an arlexecute backend

### DIFF
--- a/tests/workflows/__init__.py
+++ b/tests/workflows/__init__.py
@@ -1,0 +1,28 @@
+"""Offers he base class for arlexecute-based unit tests"""
+
+class ARLExecuteTestCase(object):
+    """Sets up the arlexecute global object as appropriate, and closes it when done"""
+
+    def setUp(self):
+        super(ARLExecuteTestCase, self).setUp()
+
+        import os
+        from wrappers.arlexecute.execution_support.arlexecute import arlexecute
+        use_dlg = os.environ.get('ARL_TESTS_USE_DLG', '0') == '1'
+        use_dask = os.environ.get('ARL_TESTS_USE_DASK', '0') == '1'
+        arlexecute.set_client(use_dask=use_dask, use_dlg=use_dlg)
+
+        # Start a daliuge node manager for these tests; make sure it can see
+        # the arl modules. The node manager will be shut down at tearDown
+        if use_dlg:
+            from dlg import tool
+            arl_root = os.path.normpath(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+            self.nm_proc = tool.start_process('nm', ['--dlg-path', arl_root])
+
+    def tearDown(self):
+        from wrappers.arlexecute.execution_support.arlexecute import arlexecute
+        arlexecute.close()
+        if arlexecute.using_dlg:
+            from dlg import utils
+            utils.terminate_or_kill(self.nm_proc, 10)
+        super(ARLExecuteTestCase, self).tearDown()

--- a/tests/workflows/test_imaging_arlexecute.py
+++ b/tests/workflows/test_imaging_arlexecute.py
@@ -11,6 +11,7 @@ import numpy
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 
+from . import ARLExecuteTestCase
 from data_models.polarisation import PolarisationFrame
 from wrappers.arlexecute.execution_support.arlexecute import arlexecute
 from wrappers.arlexecute.image.operations import export_image_to_fits, smooth_image
@@ -29,18 +30,13 @@ log.addHandler(logging.StreamHandler(sys.stdout))
 log.addHandler(logging.StreamHandler(sys.stderr))
 
 
-class TestImaging(unittest.TestCase):
+class TestImaging(ARLExecuteTestCase, unittest.TestCase):
     def setUp(self):
-        
+        super(TestImaging, self).setUp()
         from data_models.parameters import arl_path
         self.dir = arl_path('test_results')
-    
-    def tearDown(self):
-        arlexecute.close()
-    
+
     def actualSetUp(self, add_errors=False, freqwin=1, block=False, dospectral=True, dopol=False, zerow=False):
-        
-        arlexecute.set_client(use_dask=False)
         
         self.npixel = 256
         self.low = create_named_configuration('LOWBD2', rmax=750.0)

--- a/tests/workflows/test_imaging_deconvolve_arlexecute.py
+++ b/tests/workflows/test_imaging_deconvolve_arlexecute.py
@@ -13,6 +13,7 @@ from astropy.coordinates import SkyCoord
 
 from data_models.polarisation import PolarisationFrame
 
+from . import ARLExecuteTestCase
 from workflows.arlexecute.imaging.imaging_arlexecute import invert_list_arlexecute_workflow, deconvolve_list_arlexecute_workflow, \
     residual_list_arlexecute_workflow, restore_list_arlexecute_workflow
 from wrappers.arlexecute.execution_support.arlexecute import arlexecute
@@ -29,16 +30,12 @@ log.addHandler(logging.StreamHandler(sys.stdout))
 log.addHandler(logging.StreamHandler(sys.stderr))
 
 
-class TestImagingDeconvolveGraph(unittest.TestCase):
+class TestImagingDeconvolveGraph(ARLExecuteTestCase, unittest.TestCase):
     
     def setUp(self):
-        
+        super(TestImagingDeconvolveGraph, self).setUp()
         from data_models.parameters import arl_path
         self.dir = arl_path('test_results')
-        arlexecute.set_client(use_dask=False)
-    
-    def tearDown(self):
-        arlexecute.close()
     
     def actualSetUp(self, add_errors=False, freqwin=7, block=False, dospectral=True, dopol=False,
                     zerow=True):

--- a/tests/workflows/test_modelpartition_arlexecute.py
+++ b/tests/workflows/test_modelpartition_arlexecute.py
@@ -12,6 +12,7 @@ from astropy.coordinates import SkyCoord
 from data_models.memory_data_models import SkyModel
 from data_models.polarisation import PolarisationFrame
 
+from . import ARLExecuteTestCase
 from wrappers.arlexecute.calibration.operations import apply_gaintable, create_gaintable_from_blockvisibility
 from wrappers.arlexecute.calibration.calibration import solve_gaintable
 from wrappers.arlexecute.image.operations import export_image_to_fits, qa_image
@@ -31,18 +32,13 @@ from workflows.arlexecute.imaging.imaging_arlexecute import invert_list_arlexecu
 log = logging.getLogger(__name__)
 
 
-class TestCalibrationSkyModelcal(unittest.TestCase):
+class TestCalibrationSkyModelcal(ARLExecuteTestCase, unittest.TestCase):
     def setUp(self):
         
         from data_models.parameters import arl_path
         self.dir = arl_path('test_results')
         
-        arlexecute.set_client(use_dask=False)
-        
         numpy.random.seed(180555)
-
-    def tearDown(self):
-        arlexecute.close()
 
     def actualSetup(self, vnchan=1, doiso=True, ntimes=5, flux_limit=2.0, zerow=True, fixed=False):
         

--- a/tests/workflows/test_pipelines_arlexecute.py
+++ b/tests/workflows/test_pipelines_arlexecute.py
@@ -13,6 +13,7 @@ from astropy.coordinates import SkyCoord
 
 from data_models.polarisation import PolarisationFrame
 
+from . import ARLExecuteTestCase
 from wrappers.arlexecute.calibration.calibration_control import create_calibration_controls
 from wrappers.arlexecute.execution_support.arlexecute import arlexecute
 from workflows.arlexecute.pipelines.pipeline_arlexecute import ical_list_arlexecute_workflow, continuum_imaging_list_arlexecute_workflow
@@ -30,16 +31,12 @@ log.addHandler(logging.StreamHandler(sys.stdout))
 log.addHandler(logging.StreamHandler(sys.stderr))
 
 
-class TestPipelineGraphs(unittest.TestCase):
+class TestPipelineGraphs(ARLExecuteTestCase, unittest.TestCase):
     
     def setUp(self):
-        
+        super(TestPipelineGraphs, self).setUp()
         from data_models.parameters import arl_path
         self.dir = arl_path('test_results')
-        arlexecute.set_client(use_dask=False)
-
-    def tearDown(self):
-        arlexecute.close()
 
     def actualSetUp(self, add_errors=False, freqwin=5, block=False, dospectral=True, dopol=False,
                     amp_errors=None, phase_errors=None, zerow=True):

--- a/tests/workflows/test_simulation_arlexecute.py
+++ b/tests/workflows/test_simulation_arlexecute.py
@@ -9,6 +9,7 @@ import numpy
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 
+from . import ARLExecuteTestCase
 from data_models.memory_data_models import BlockVisibility
 from wrappers.arlexecute.execution_support.arlexecute import arlexecute
 
@@ -17,9 +18,9 @@ from workflows.arlexecute.simulation.simulation_arlexecute import simulate_list_
 log = logging.getLogger(__name__)
 
 
-class TestSimulationArlexecuteSupport(unittest.TestCase):
+class TestSimulationArlexecuteSupport(ARLExecuteTestCase, unittest.TestCase):
     def setUp(self):
-    
+        super(TestSimulationArlexecuteSupport, self).setUp()
         from data_models.parameters import arl_path
         self.dir = arl_path('test_results')
         
@@ -27,10 +28,6 @@ class TestSimulationArlexecuteSupport(unittest.TestCase):
         self.channel_bandwidth = numpy.array([2.5e7, 2.5e7, 2.5e7])
         self.phasecentre = SkyCoord(ra=+15.0 * u.deg, dec=-60.0 * u.deg, frame='icrs', equinox='J2000')
         self.times = numpy.linspace(-300.0, 300.0, 3) * numpy.pi / 43200.0
-        arlexecute.set_client(use_dask=False)
-
-    def tearDown(self):
-        arlexecute.close()
 
     def test_create_simulate_vis_list(self):
         vis_list = simulate_list_arlexecute_workflow(frequency=self.frequency, channel_bandwidth=self.channel_bandwidth)

--- a/wrappers/arlexecute/execution_support/arlexecute.py
+++ b/wrappers/arlexecute/execution_support/arlexecute.py
@@ -8,15 +8,28 @@ import time
 from dask import delayed
 from dask.distributed import Client, wait
 
+# Support daliuge's delayed function, make it fail if not available but used
+try:
+    from dlg import delayed as dlg_delayed
+except ImportError:
+    def dlg_delayed(*args, **kwargs):
+        raise Exception("daliuge is not available")
+
 log = logging.getLogger(__name__)
 
 
 class ARLExecuteBase():
     
-    def __init__(self, use_dask=True):
+    def __init__(self, use_dask=True, use_dlg=False):
+        if bool(use_dask) and bool(use_dlg):
+            raise ValueError('use_dask and use_dlg cannot be specified together')
+        self._set_state(use_dask, use_dlg, None)
+
+    def _set_state(self, use_dask, use_dlg, client):
         self._using_dask = use_dask
-        self._client = None
-    
+        self._using_dlg = use_dlg
+        self._client = client
+
     def execute(self, func, *args, **kwargs):
         """ Wrap for immediate or deferred execution
         
@@ -28,6 +41,8 @@ class ARLExecuteBase():
         """
         if self._using_dask:
             return delayed(func, *args, **kwargs)
+        elif self._using_dlg:
+            return dlg_delayed(func, *args, **kwargs)
         else:
             return func
     
@@ -38,11 +53,13 @@ class ARLExecuteBase():
         """
         if self._using_dask:
             return 'dask'
+        elif self._using_dlg:
+            return 'daliuge'
         else:
             return 'function'
     
-    def set_client(self, client=None, use_dask=True, **kwargs):
-        """Set the Dask client to be used
+    def set_client(self, client=None, use_dask=True, use_dlg=False, **kwargs):
+        """Set the Dask/DALiuGE client to be used
         
         !!!This must be called before calling execute!!!!
         
@@ -50,19 +67,20 @@ class ARLExecuteBase():
         :param client: If None and use_dask is True, a client will be created otherwise the client is None
         :return:
         """
+        if bool(use_dask) and bool(use_dlg):
+            raise ValueError('use_dask and use_dlg cannot be specified together')
+
         if isinstance(self._client, Client):
             self.client.close()
         
         if use_dask:
-            if client is None:
-                self._client = Client(**kwargs)
-            else:
-                assert isinstance(client, Client)
-                self._client = client
-            self._using_dask = True
+            client = client or Client(**kwargs)
+            assert isinstance(client, Client)
+            self._set_state(True, False, client)
+        elif use_dlg:
+            self._set_state(False, True, client)
         else:
-            self._client = None
-            self._using_dask = False
+            self._set_state(False, False, None)
     
     def compute(self, value, sync=False):
         """Get the actual value
@@ -85,6 +103,9 @@ class ARLExecuteBase():
                 log.debug("arlexecute.compute: Execution using Dask took %.3f seconds" % duration)
                 print("arlexecute.compute: Execution using Dask took %.3f seconds" % duration)
             return future
+        elif self._using_dlg:
+            kwargs = {'client': self._client} if self._client else {}
+            return value.compute(**kwargs)
         else:
             return value
     
@@ -131,6 +152,10 @@ class ARLExecuteBase():
     def using_dask(self):
         return self._using_dask
     
+    @property
+    def using_dlg(self):
+        return self._using_dlg
+
     def close(self):
         if self._using_dask and isinstance(self._client, Client):
             print('arlexcute.close: closing down Dask Client')


### PR DESCRIPTION
This pull request is to add support for daliuge as an (experimental) backend of the `arlexecute` module. Support uses daliuge's `delayed` function, which accepts the same parameters as dask's; therefore the change is simply, and transparent to the rest of the ARL code.

I am not so sure having more `use_this` and `use_that` flags is the way to go now that there are more than two backends (i.e., "normal" python execution, dask delayed and daliuge delayed). Maybe an enumeration or set of constants could be used instead? Anyhow, I wanted to keep the changes to the bare minimum at the moment.

In terms of an ARL installation, daliuge is still not a requirement; however if a user requires it and it is not found then an error is issued accordingly.

Finally, some helper code has been added so the tests under tests/workflows can dynamically select which arlexecute backend to use without having to change the code in the tests.

All these changes are within the context of SDP ticket TSK-2569. A more complete report about what has changed and the tests I've run can be found in that ticket as well.