### PR TITLE
UVFITS Reader

### DIFF
--- a/data/vis/ASKAP_example.fits
+++ b/data/vis/ASKAP_example.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5b24b8b023ba5100b2ba964899be643d5d68f7a931f075cd8c9bff801f80247
+size 9702720

--- a/processing_components/visibility/base.py
+++ b/processing_components/visibility/base.py
@@ -7,9 +7,12 @@ import logging
 from typing import Union
 
 import numpy
+import re
 from astropy import constants as constants
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
+from astropy.time import Time
 
 from data_models.memory_data_models import Visibility, BlockVisibility, Configuration
 from data_models.polarisation import PolarisationFrame, ReceptorFrame, correlate_polarisation
@@ -420,3 +423,188 @@ def create_visibility_from_ms(msname, channum=None, ack=False):
     return [convert_blockvisibility_to_visibility(v)
             for v in create_blockvisibility_from_ms(msname=msname, channum=channum, ack=ack)]
 
+
+def create_blockvisibility_from_uvfits(fitsname, channum=None, ack=False, antnum=None):
+    """ Minimal UVFIT to BlockVisibility converter
+
+    The UVFITS format is much more general than the ARL BlockVisibility so we cut many corners. 
+    
+    Creates a list of BlockVisibility's, split by field and spectral window
+    
+    :param msname: File name of UVFITS
+    :param channum: range of channels e.g. range(17,32), default is None meaning all
+    :param antnum: the number of antenna
+    :return:
+    """
+    def ParamDict(hdul):
+        "Return the dictionary of the random parameters"
+
+        """
+        The keys of the dictionary are the parameter names uppercased for
+        consistency. The values are the column numbers.
+
+        If multiple parameters have the same name (e.g., DATE) their
+        columns are entered as a list.
+        """
+
+        pre=re.compile(r"PTYPE(?P<i>\d+)")
+        res={}
+        for k,v in hdul.header.items():
+            m=pre.match(k)
+            if m :
+                vu=v.upper()
+                if vu in res:
+                    res[ vu ] = [ res[vu], int(m.group("i")) ]
+                else:
+                    res[ vu ] = int(m.group("i"))
+        return res
+
+
+    # Open the file
+    with fits.open(fitsname) as hdul:
+
+        # Read Spectral Window
+        nspw = hdul[0].header['NAXIS5']
+        # Read Channel and Frequency Interval
+        freq_ref = hdul[0].header['CRVAL4']
+        mid_chan_freq = hdul[0].header['CRPIX4']
+        delt_freq = hdul[0].header['CDELT4']
+        # Real the number of channels in one spectral window
+        channels = hdul[0].header['NAXIS4']
+        freq = numpy.zeros([nspw, channels])
+        # Read Frequency or IF
+        freqhdulname="AIPS FQ"
+        sdhu  = hdul.index_of(freqhdulname)
+        if_freq = hdul[sdhu].data['IF FREQ'].ravel()
+        for i in range(nspw):
+            temp = numpy.array([if_freq[i] + freq_ref+delt_freq* ff for ff in range(channels)])
+            freq[i,:] = temp[:]
+        freq_delt = numpy.ones(channels) * delt_freq
+        if channum is None:
+            channum = range(channels)
+
+        primary = hdul[0].data
+        # Read time
+        bvtimes = Time(hdul[0].data['DATE'], hdul[0].data['_DATE'], format='jd')
+        bv_times  = numpy.unique(bvtimes.jd)
+        ntimes   = len(bv_times)
+
+                # # Get Antenna
+        # blin = hdul[0].data['BASELINE']
+        antennahdulname="AIPS AN"
+        adhu  = hdul.index_of(antennahdulname)
+        try:
+            antenna_name = hdul[adhu].data['ANNAME']
+            antenna_name = antenna_name.encode('ascii','ignore')
+        except:
+            antenna_name = None
+
+        antenna_xyz = hdul[adhu].data['STABXYZ']
+        antenna_mount =  hdul[adhu].data['MNTSTA']
+        try:
+            antenna_diameter = hdul[adhu].data['DIAMETER']
+        except:
+            antenna_diameter = None
+        # To reading some UVFITS with wrong numbers of antenna
+        if antnum is not None:
+            if antenna_name is not None:
+                antenna_name = antenna_name[:antnum]
+                antenna_xyz = antenna_xyz[:antnum]
+                antenna_mount = antenna_mount[:antnum]
+                if antenna_diameter is not None:
+                    antenna_diameter = antenna_diameter[:antnum]
+        nants = len(antenna_xyz)
+
+        # res= {}
+        # for i,row in enumerate(fin[ahdul].data):
+        #     res[row.field("ANNAME") ]  = i +1
+
+        # Get polarisation info
+        npol = hdul[0].header['NAXIS3']
+        corr_type = numpy.arange(hdul[0].header['NAXIS3']) - (hdul[0].header['CRPIX3'] - 1)
+        corr_type *= hdul[0].header['CDELT3']
+        corr_type += hdul[0].header['CRVAL3']
+        # xx yy xy yx
+        # These correspond to the CASA Stokes enumerations
+        if numpy.array_equal(corr_type, [1, 2, 3, 4]):
+            polarisation_frame = PolarisationFrame('stokesIQUV')
+        elif numpy.array_equal(corr_type, [-1, -2, -3, -4]):
+            polarisation_frame = PolarisationFrame('circular')
+        elif numpy.array_equal(corr_type, [-5, -6, -7, -8]):
+            polarisation_frame = PolarisationFrame('linear')
+        else:
+            raise KeyError("Polarisation not understood: %s" % str(corr_type))            
+
+        configuration = Configuration(name='', data=None, location=None,
+                                        names=antenna_name, xyz=antenna_xyz, mount=antenna_mount, frame=None,
+                                        receptor_frame=polarisation_frame,
+                                        diameter=antenna_diameter)       
+
+        # Get RA and DEC
+        phase_center_ra_degrees = numpy.float(hdul[0].header['CRVAL6'])
+        phase_center_dec_degrees = numpy.float(hdul[0].header['CRVAL7'])
+
+        # Get phasecentres
+        phasecentre = SkyCoord(ra=phase_center_ra_degrees * u.deg, dec=phase_center_dec_degrees * u.deg, frame='icrs', equinox='J2000')
+                    
+        # Get UVW
+        d=ParamDict(hdul[0])
+        if "UU" in d:
+            uu = hdul[0].data['UU'] 
+            vv = hdul[0].data['VV'] 
+            ww = hdul[0].data['WW'] 
+        else:
+            uu = hdul[0].data['UU---SIN'] 
+            vv = shdul[0].data['VV---SIN'] 
+            ww = hdul[0].data['WW---SIN'] 
+        _vis = hdul[0].data['DATA']
+
+        #_vis.shape = (nchan, ntimes, (nants*(nants-1)//2 ), npol, -1)
+        #self.vis = -(_vis[...,0] * 1.j + _vis[...,1])
+        row = 0
+        nchan = len(channum)
+        vis_list = list()
+        for spw_index in range(nspw):
+            bv_vis = numpy.zeros([ntimes, nants, nants, nchan, npol]).astype('complex')
+            bv_weight = numpy.zeros([ntimes, nants, nants, nchan, npol])
+            bv_uvw = numpy.zeros([ntimes, nants, nants, 3])     
+            for time_index , time in enumerate(bv_times):
+                #restfreq = freq[channel_index] 
+                for antenna1 in range(nants-1):
+                    for antenna2 in range(antenna1 + 1, nants):
+                        for channel_no, channel_index in enumerate(channum):
+                            for pol_index in range(npol):
+                                bv_vis[time_index, antenna2, antenna1, channel_no,pol_index] = complex(_vis[row,:,:,spw_index,channel_index, pol_index ,0],_vis[row,:,:,spw_index,channel_index,pol_index ,1])
+                                bv_weight[time_index, antenna2, antenna1, channel_no, pol_index] = _vis[row,:,:,spw_index,channel_index,pol_index ,2]
+                        bv_uvw[time_index, antenna2, antenna1, 0] = uu[row]* constants.c.value
+                        bv_uvw[time_index, antenna2, antenna1, 1] = vv[row]* constants.c.value
+                        bv_uvw[time_index, antenna2, antenna1, 2] = ww[row]* constants.c.value
+                        row += 1 
+            vis_list.append(BlockVisibility(uvw=bv_uvw,
+                                            time=bv_times,
+                                            frequency=freq[spw_index][channum],
+                                            channel_bandwidth=freq_delt[channum],
+                                            vis=bv_vis,
+                                            weight=bv_weight,
+                                            imaging_weight= bv_weight,
+                                            configuration=configuration,
+                                            phasecentre=phasecentre,
+                                            polarisation_frame=polarisation_frame))
+    return vis_list
+
+def create_visibility_from_uvfits(fitsname, channum=None, ack=False, antnum=None):
+    """ Minimal MS to BlockVisibility converter
+
+    The MS format is much more general than the ARL BlockVisibility so we cut ma ny corners. This requires casacore to be
+    installed. If not an exception ModuleNotFoundError is raised.
+
+    Creates a list of BlockVisibility's, split by field and spectral window
+
+    :param msname: File name of MS
+    :param channum: range of channels e.g. range(17,32), default is None meaning all
+    :param antnum: the number of antenna
+    :return:
+    """
+    from processing_components.visibility.coalesce import convert_blockvisibility_to_visibility
+    return [convert_blockvisibility_to_visibility(v)
+            for v in create_blockvisibility_from_uvfits(fitsname=fitsname, channum=channum, ack=ack, antnum=antnum)]

--- a/processing_components/visibility/operations.py
+++ b/processing_components/visibility/operations.py
@@ -14,7 +14,7 @@ from data_models.polarisation import convert_linear_to_stokes, convert_circular_
     convert_linear_to_stokesI, convert_circular_to_stokesI
 from processing_library.imaging.imaging_params import get_frequency_map
 from processing_library.util.coordinate_support import skycoord_to_lmn, simulate_point
-from ..visibility.base import copy_visibility
+from processing_components.visibility.base import copy_visibility
 
 log = logging.getLogger(__name__)
 

--- a/tests/processing_components/test_visibility_uvfits.py
+++ b/tests/processing_components/test_visibility_uvfits.py
@@ -1,0 +1,95 @@
+""" Unit tests for visibility operations
+    
+    
+    """
+import sys
+import unittest
+import logging
+
+import numpy
+from data_models.parameters import arl_path
+from data_models.polarisation import PolarisationFrame
+
+from processing_components.visibility.base import create_blockvisibility_from_uvfits, create_visibility_from_uvfits
+from processing_components.visibility.operations import integrate_visibility_by_channel
+from processing_components.imaging.base import invert_2d, create_image_from_visibility
+from processing_components.visibility.coalesce import convert_visibility_to_blockvisibility, \
+    convert_blockvisibility_to_visibility
+
+log = logging.getLogger(__name__)
+
+log.setLevel(logging.DEBUG)
+log.addHandler(logging.StreamHandler(sys.stdout))
+log.addHandler(logging.StreamHandler(sys.stderr))
+
+
+class TestCreateMS(unittest.TestCase):
+    
+    def setUp(self):
+        return
+    
+    # def test_create_list(self):
+    #     uvfitsfile = arl_path("data/vis/xcasa.fits")
+    #     self.vis = create_blockvisibility_from_uvfits(uvfitsfile)
+    
+    #     for v in self.vis:
+    #         assert v.vis.data.shape[-1] == 4
+    #         assert v.polarisation_frame.type == "circular"
+    
+    def test_create_list_spectral(self):
+        
+        uvfitsfile = arl_path("data/vis/ASKAP_example.fits")
+        
+        vis_by_channel = list()
+        nchan_ave = 16
+        nchan = 192
+        for schan in range(0, nchan, nchan_ave):
+            max_chan = min(nchan, schan + nchan_ave)
+            v = create_visibility_from_uvfits(uvfitsfile, range(schan, max_chan))
+            vis_by_channel.append(v[0])
+        
+        assert len(vis_by_channel) == 12
+        for v in vis_by_channel:
+            assert v.vis.data.shape[-1] == 4
+            assert v.polarisation_frame.type == "linear"
+
+def test_create_list_spectral_average(self):
+    
+    uvfitsfile = arl_path("data/vis/ASKAP_example.fits")
+    
+    vis_by_channel = list()
+        nchan_ave = 16
+        nchan = 192
+        for schan in range(0, nchan, nchan_ave):
+            max_chan = min(nchan, schan + nchan_ave)
+            v = create_blockvisibility_from_uvfits(uvfitsfile, range(schan, max_chan))
+            vis_by_channel.append(integrate_visibility_by_channel(v[0]))
+
+    assert len(vis_by_channel) == 12
+        for v in vis_by_channel:
+            assert v.vis.data.shape[-1] == 4
+            assert v.vis.data.shape[-2] == 1
+            assert v.polarisation_frame.type == "linear"
+
+def test_invert(self):
+    
+    uvfitsfile = arl_path("data/vis/ASKAP_example.fits")
+    
+    nchan_ave = 32
+        nchan = 192
+        for schan in range(0, nchan, nchan_ave):
+            max_chan = min(nchan, schan + nchan_ave)
+            bv = create_blockvisibility_from_uvfits(uvfitsfile, range(schan, max_chan))[0]
+            vis = convert_blockvisibility_to_visibility(bv)
+            from processing_components.visibility.operations import convert_visibility_to_stokesI
+            vis = convert_visibility_to_stokesI(vis)
+            print(vis)
+            model = create_image_from_visibility(vis, npixel=256, polarisation_frame=PolarisationFrame('stokesI'))
+            dirty, sumwt = invert_2d(vis, model, context='2d')
+            assert (numpy.max(numpy.abs(dirty.data))) > 0.0
+            assert dirty.shape == (nchan_ave, 1, 256, 256)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/processing_components/test_visibility_uvfits.py
+++ b/tests/processing_components/test_visibility_uvfits.py
@@ -53,41 +53,41 @@ class TestCreateMS(unittest.TestCase):
             assert v.vis.data.shape[-1] == 4
             assert v.polarisation_frame.type == "linear"
 
-def test_create_list_spectral_average(self):
-    
-    uvfitsfile = arl_path("data/vis/ASKAP_example.fits")
-    
-    vis_by_channel = list()
-        nchan_ave = 16
-        nchan = 192
-        for schan in range(0, nchan, nchan_ave):
-            max_chan = min(nchan, schan + nchan_ave)
-            v = create_blockvisibility_from_uvfits(uvfitsfile, range(schan, max_chan))
-            vis_by_channel.append(integrate_visibility_by_channel(v[0]))
+    def test_create_list_spectral_average(self):
+        
+        uvfitsfile = arl_path("data/vis/ASKAP_example.fits")
+        
+        vis_by_channel = list()
+            nchan_ave = 16
+            nchan = 192
+            for schan in range(0, nchan, nchan_ave):
+                max_chan = min(nchan, schan + nchan_ave)
+                v = create_blockvisibility_from_uvfits(uvfitsfile, range(schan, max_chan))
+                vis_by_channel.append(integrate_visibility_by_channel(v[0]))
 
-    assert len(vis_by_channel) == 12
-        for v in vis_by_channel:
-            assert v.vis.data.shape[-1] == 4
-            assert v.vis.data.shape[-2] == 1
-            assert v.polarisation_frame.type == "linear"
+        assert len(vis_by_channel) == 12
+            for v in vis_by_channel:
+                assert v.vis.data.shape[-1] == 4
+                assert v.vis.data.shape[-2] == 1
+                assert v.polarisation_frame.type == "linear"
 
-def test_invert(self):
-    
-    uvfitsfile = arl_path("data/vis/ASKAP_example.fits")
-    
-    nchan_ave = 32
-        nchan = 192
-        for schan in range(0, nchan, nchan_ave):
-            max_chan = min(nchan, schan + nchan_ave)
-            bv = create_blockvisibility_from_uvfits(uvfitsfile, range(schan, max_chan))[0]
-            vis = convert_blockvisibility_to_visibility(bv)
-            from processing_components.visibility.operations import convert_visibility_to_stokesI
-            vis = convert_visibility_to_stokesI(vis)
-            print(vis)
-            model = create_image_from_visibility(vis, npixel=256, polarisation_frame=PolarisationFrame('stokesI'))
-            dirty, sumwt = invert_2d(vis, model, context='2d')
-            assert (numpy.max(numpy.abs(dirty.data))) > 0.0
-            assert dirty.shape == (nchan_ave, 1, 256, 256)
+    def test_invert(self):
+        
+        uvfitsfile = arl_path("data/vis/ASKAP_example.fits")
+        
+        nchan_ave = 32
+            nchan = 192
+            for schan in range(0, nchan, nchan_ave):
+                max_chan = min(nchan, schan + nchan_ave)
+                bv = create_blockvisibility_from_uvfits(uvfitsfile, range(schan, max_chan))[0]
+                vis = convert_blockvisibility_to_visibility(bv)
+                from processing_components.visibility.operations import convert_visibility_to_stokesI
+                vis = convert_visibility_to_stokesI(vis)
+                print(vis)
+                model = create_image_from_visibility(vis, npixel=256, polarisation_frame=PolarisationFrame('stokesI'))
+                dirty, sumwt = invert_2d(vis, model, context='2d')
+                assert (numpy.max(numpy.abs(dirty.data))) > 0.0
+                assert dirty.shape == (nchan_ave, 1, 256, 256)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi Tim, 

Thank you for the consideration to include UVFITS support in ARL. 

1. base.py:  We add two functions such as create_blockvisibility_from_uvfits and create_visibility_from_uvfits. The codes have been tested strictly. Frankly speaking, the current function can't support all variations of UVFITS because it's too complex. The arguments of the functions are similar to the functions of MS file. 

2. test_visibility_uvfits: Testing codes 

3. ASKAP_example.fits :  I finally upload the testing data because I found test program can't pass.
Cheers, 

Feng